### PR TITLE
Refactoring the main DDC script

### DIFF
--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -294,7 +294,8 @@ process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TR
     select(- latitude, -longitude, -species_code)
   
   ## Return tables for next step ----------------------------------------------
-  return(list(hauls_survey = hauls_survey, 
+  return(list(slope_survey = slope_survey,
+              hauls_survey = hauls_survey, 
               pollock_specimen = pollock_specimen,
               pollock_catch = pollock_catch,
               pollock_length = pollock_length,
@@ -392,12 +393,12 @@ db_bootstrap <- bootstrapping()
 
 
 # Check and save model-based results (for VAST) -------------------------------
-if(data_type == 'mb')
-{
+if(data_type == 'mb') {
   VAST_files <- make_VAST_input(hauls = hauls_survey,
                                 spec = pollock_specimen,
                                 ddc_index = ddc_table,
-                                ddc_age = ddc_alk)
+                                ddc_age = ddc_alk,
+                                slope_survey = tables$slope_survey)
   VAST_ddc_alk <- VAST_files$VAST_ddc_alk %>% 
     filter(Age >= 1) # check
   

--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -120,12 +120,12 @@ NBS_subarea <- c(81, 70, 71, 99) # NBS stratum numbers; added 99 to indicate 201
 # Strata metadata year; 2022 is the latest update (use for current assessments)
 strat_meta_year <- 2022
 
+# Set output - model- or design-based
 data_type <- "mb"
 
 # Set up folder 
 dir_thisyr <- paste0(current_year,"_", data_type, "_data_", strat_meta_year, "_strata")
 dir.create(here("output",dir_thisyr))
-
 
 # data --------------------------------------------------------------------
 process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TRUE) {
@@ -150,17 +150,18 @@ process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TR
   get_hauls <- haul_data_d(data_selection = data_type, 
                            nbs_subarea = NBS_subarea, 
                            slope_info = slope_survey)
-
-  hauls_survey_ebs <- get_hauls$good_hauls_DB_EBS
-  hauls_survey_nbs <- get_hauls$good_hauls_DB_NBS
-  hauls_survey_bad_ebs <- get_hauls$bad_hauls_DB_ebs
-  hauls_survey_bad_nbs <- get_hauls$bad_hauls_DB_nbs
-  all_hauljoins <- c(hauls_survey_ebs$hauljoin, hauls_survey_bad_ebs$hauljoin)
-  all_hauljoins_nbs <- c(hauls_survey_nbs$hauljoin, hauls_survey_bad_nbs$hauljoin)
-  valid_hauljoins_nbs <- hauls_survey_nbs$hauljoin
-  hauls_survey <- hauls_survey_ebs %>% bind_rows(hauls_survey_nbs)
-  hauls_survey_bad <- hauls_survey_bad_ebs %>% bind_rows(hauls_survey_bad_nbs)
   
+  if(data_type == "db") {
+    hauls_survey_ebs <- get_hauls$good_hauls_DB_EBS
+    hauls_survey_nbs <- get_hauls$good_hauls_DB_NBS
+    hauls_survey_bad_ebs <- get_hauls$bad_hauls_DB_ebs
+    hauls_survey_bad_nbs <- get_hauls$bad_hauls_DB_nbs
+    all_hauljoins <- c(hauls_survey_ebs$hauljoin, hauls_survey_bad_ebs$hauljoin)
+    all_hauljoins_nbs <- c(hauls_survey_nbs$hauljoin, hauls_survey_bad_nbs$hauljoin)
+    valid_hauljoins_nbs <- hauls_survey_nbs$hauljoin
+    hauls_survey <- hauls_survey_ebs %>% bind_rows(hauls_survey_nbs)
+    hauls_survey_bad <- hauls_survey_bad_ebs %>% bind_rows(hauls_survey_bad_nbs)
+  }
   if(data_type == "mb") {
     hauls_survey <- get_hauls$good_hauls_MB
     hauls_survey_bad <- get_hauls$bad_hauls

--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -146,14 +146,17 @@ NBS_subarea <- c(81, 70, 71, 99) # NBS stratum numbers; added 99 to indicate 201
 strat_meta_year <- 2022
 
 # Set output - model- or design-based
-data_type <- "db"
+data_type <- "mb"
+
+# Estimate ages from the age-length key (when there are no ages before the production run)
+estimate_ages <- TRUE
 
 # Set up folder 
 dir_thisyr <- paste0(current_year,"_", data_type, "_data_", strat_meta_year, "_strata")
 dir.create(here("output",dir_thisyr))
 
 # data --------------------------------------------------------------------
-process_data <- function(first_run = FALSE, estimate_ages = FALSE, save_data = FALSE) {
+process_data <- function(first_run = FALSE, save_data = FALSE) {
   # Don't include slope survey for VAST
   slope_survey <- slope_survey_d()
   

--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -153,7 +153,7 @@ dir_thisyr <- paste0(current_year,"_", data_type, "_data_", strat_meta_year, "_s
 dir.create(here("output",dir_thisyr))
 
 # data --------------------------------------------------------------------
-process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TRUE) {
+process_data <- function(first_run = FALSE, estimate_ages = FALSE, save_data = FALSE) {
   # Don't include slope survey for VAST
   slope_survey <- slope_survey_d()
   
@@ -317,8 +317,8 @@ process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TR
     rename(latitude = start_latitude, longitude = start_longitude) %>% 
     select(- latitude, -longitude, -species_code)
   
-  ## Return tables for next step ----------------------------------------------
-  return(list(slope_survey = slope_survey,
+  ## Return tables for next steps ---------------------------------------------
+  out <- list(slope_survey = slope_survey,
               hauls_survey = hauls_survey, 
               pollock_specimen = pollock_specimen,
               pollock_catch = pollock_catch,
@@ -329,7 +329,15 @@ process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TR
               cpue_length_table = cpue_length_table,
               age_comp_full_key = age_comp_full_key,
               ddc_table = ddc_table, 
-              cpue_info = cpue_info))
+              cpue_info = cpue_info)
+  
+  if(data_type == "mb") {return(out)}
+  
+  if(data_type == "db") {
+    extra <- list(hauls_survey_ebs = hauls_survey_ebs, hauls_survey_nbs = hauls_survey_nbs)
+    out2 <- c(out, extra)
+    return(out2)
+  }
 }
 
 tables <- process_data()

--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -393,6 +393,10 @@ db_bootstrap <- bootstrapping()
 
 
 # Check and save model-based results (for VAST) -------------------------------
+# Repeated file path pieces
+output <- here("output", dir_thisyr)
+file_end <- paste0("_", current_year, ".csv")
+
 if(data_type == 'mb') {
   VAST_files <- make_VAST_input(hauls = hauls_survey,
                                 spec = pollock_specimen,
@@ -409,18 +413,14 @@ if(data_type == 'mb') {
   print(table(VAST_ddc_alk$Age)) #check that sample size is same for each!
   
   ## Write out tables for VAST ------------------------------------------------
-  # Biomass for EBS + NBS together - dd correction 
-  write_csv(VAST_files$VAST_ddc_table, 
-            here("output", dir_thisyr, paste0("VAST_ddc_all_", current_year, ".csv")))
-  # Biomass for just EBS - dd correction
-  write_csv(VAST_files$VAST_ddc_table_EBS, 
-            here("output", dir_thisyr, paste0("VAST_ddc_EBSonly_", current_year, ".csv")))
-  # Biomass for just NBS - dd correction
-  write_csv(VAST_files$VAST_ddc_table_NBS, 
-            here("output", dir_thisyr, paste0("VAST_ddc_NBSonly_", current_year, ".csv")))
-  # Age comps for EBS + NBS together - dd correction
-  write_csv(VAST_ddc_alk, 
-            here("output", dir_thisyr, paste0("VAST_ddc_alk_", current_year, ".csv")))
+  write_csv(VAST_files$VAST_ddc_table,  # Biomass for EBS + NBS together - dd correction 
+            here(output, paste0("VAST_ddc_all", file_end)))
+  write_csv(VAST_files$VAST_ddc_table_EBS,  # Biomass for just EBS - dd correction
+            here(output, paste0("VAST_ddc_EBSonly", file_end)))
+  write_csv(VAST_files$VAST_ddc_table_NBS,  # Biomass for just NBS - dd correction
+            here(output, paste0("VAST_ddc_NBSonly", file_end)))
+  write_csv(VAST_ddc_alk,  # Age comps for EBS + NBS together - dd correction
+            here(output, paste0("VAST_ddc_alk", file_end)))
 }
 
 
@@ -429,34 +429,34 @@ if(data_type == 'mb') {
 if(data_type == 'db') {
   # Tables Jim Ianelli needs (all EBS + NBS):
   write_csv(tables$cpue_info$avg_cpue_yr_strat,  # CPUE (number of fish) - uncorrected 
-            here("output", dir_thisyr,paste0("CPUE_uncorrected_", current_year, ".csv")))
+            here(output, paste0("CPUE_uncorrected", file_end)))
   write_csv(tables$cpue_info$p_cpue,  # add CPUE by station  
-            here("output", dir_thisyr, paste0("CPUE_bystn_uncorrected_", current_year, ".csv")))
+            here(output, paste0("CPUE_bystn_uncorrected", file_end)))
   
   write_csv(ddc$ddc_cpue,  # CPUE (number of fish) - dd corrected  
-            here("output", dir_thisyr, paste0("CPUE_densdep_corrected_", current_year, ".csv")))
+            here(output, paste0("CPUE_densdep_corrected", file_end)))
   write_csv(ddc_table,  # add CPUE by station 
-            here("output", dir_thisyr, paste0("CPUE_densdep_bystn_corrected_", current_year, ".csv")))
+            here(output, paste0("CPUE_densdep_bystn_corrected", file_end)))
   
   write_csv(tables$cpue_length_table,  # CPUE (number of fish, by length) - uncorrected 
-            here("output", dir_thisyr, paste0("length_cpue_numfish_uncorrected_", current_year, ".csv")))
+            here(output, paste0("length_cpue_numfish_uncorrected", file_end)))
   write_csv(tables$pop_info$pollock_biomass_MT_ha,  # Biomass (thousands of tons) - uncorrected 
-            here("output", dir_thisyr, paste0("biomass_uncorrected_", current_year, ".csv")))
+            here(output, paste0("biomass_uncorrected", file_end)))
   write_csv(ddc$ddc_pop_ests$pollock_biomass_MT_ha,  # Biomass (thousands of tons) - dd corrected
-            here("output", dir_thisyr, paste0("biomass_densdep_corrected_", current_year, ".csv")))
+            here(output, paste0("biomass_densdep_corrected", file_end)))
   write_csv(ddc$ddc_pop_ests_EBS,  # Biomass (thousands of tons) just EBS - dd corrected
-            here("output", dir_thisyr, paste0("biomass_densdep_corrected_EBSonly_", current_year, ".csv")))
+            here(output, paste0("biomass_densdep_corrected_EBSonly", file_end)))
   write_csv(ddc$ddc_pop_ests_NBS,  # Biomass (thousands of tons) just NBS - dd corrected 
-            here("output", dir_thisyr, paste0("biomass_densdep_corrected_NBSonly_", current_year, ".csv")))
+            here(output, paste0("biomass_densdep_corrected_NBSonly", file_end)))
   
   # Variance-covariance tables from Stan's method
   write_csv(as.data.frame(db_bootstrap$bioms), 
-            here("output", dir_thisyr, paste0("bootstrap_biomass_tons_stan_method", current_year,"_", data_type, ".csv")))
+            here(output, paste0("bootstrap_biomass_tons_stan_method", current_year,"_", data_type, ".csv")))
   write_csv(as.data.frame(db_bootstrap$var_covar_stan), 
-            here("output", dir_thisyr, paste0("var_cov_matrix_tons_stan_method", current_year,"_", data_type, ".csv")))
+            here(output, paste0("var_cov_matrix_tons_stan_method", current_year,"_", data_type, ".csv")))
   
   write_csv(ddc$ddc_cpue_length_table,  # Length compositions - dd corrected 
-            here("output", dir_thisyr, paste0("length_comps_densdep_corrected_", current_year, ".csv")))
+            here(output, paste0("length_comps_densdep_corrected", file_end)))
   
   # Calculate metrics of hauls, number of lengths, etc. per year
   annual_metrics <- get_annual_metrics(hauls_ebs = hauls_survey_ebs, 
@@ -469,19 +469,19 @@ if(data_type == 'db') {
                                        nbs_subarea = NBS_subarea)
   
   write_lines(annual_metrics$num_hauls_tot,  # Number of stations (by year)
-              here("output", dir_thisyr, paste0("info_hauls_peryr_", current_year, ".txt")))
+              here(output, paste0("info_hauls_peryr", file_end)))
   write_lines(annual_metrics$fish_measured,  # Number of fish measured (by year)
-              here("output", dir_thisyr, paste0("info_n_fish_measured_", current_year, ".txt")))
+              here(output, paste0("info_n_fish_measured", file_end)))
   write_lines(fish_aged,  # Number of fish aged (by year)
-              here("output", dir_thisyr, paste0("info_n_fish_aged_", current_year, ".txt")))
+              here(output, paste0("info_n_fish_aged", file_end)))
   
   # Extra stuff
   write_csv(ddc_alk,  # Full DDC ALK
-            here("output", dir_thisyr, paste0("age_length_key_full_densdep_corrected", current_year, ".csv")))
+            here(output, paste0("age_length_key_full_densdep_corrected", file_end)))
   write_csv(age_comp_full_key, 
-            here("output", dir_thisyr, paste0("age_length_key_full_uncorrected_", current_year, ".csv")))
+            here(output, paste0("age_length_key_full_uncorrected_", file_end)))
   write_csv(ddc_al_key,  # DDC ALK summary
-            here("output", dir_thisyr, paste0("age_length_key_SUMMARY_densdep_corrected", current_year, ".csv")))
+            here(output, paste0("age_length_key_SUMMARY_densdep_corrected", file_end)))
   
 }
 

--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -115,60 +115,42 @@ cruise_id_nums <- cruise_info %>% dplyr::filter(vessel_id %in% vessel_nums)
 cruise_id <- paste0(cruise_id_nums$cruise_id[1], "," , cruise_id_nums$cruise_id[2],
                     "," , cruise_id_nums$cruise_id[3], "," , cruise_id_nums$cruise_id[4])
 
-# cruise_id <- paste0(cruise_id_nums$cruise_id[1], "," , cruise_id_nums$cruise_id[2])
-
 # NBS subarea stratum-- this shouldn't change too much, but is a fixed input
 NBS_subarea <- c(81, 70, 71, 99) # NBS stratum numbers; added 99 to indicate 2018 NBS emergency survey; diff survey methods
 
-# data --------------------------------------------------------------------
+# Model- or design-based data (mb or db) 
+data_type <- mb
 
-# fixed selections ------------------------------------------------------
-# do you want model-based or design-based data?
-data_type <- (readline(prompt = "Do you want model-based or design-based data (Enter: MB or DB): "))
-mb
-if(data_type == "MB"){data_type <- "mb"}
-if(data_type == "DB"){data_type <-  "db"}
+# Strata metadata year; 2022 is the latest update (use for current assessments)
+strat_meta_year <- 2022
 
-# which strata_metadata do you want to use?
-strat_meta_year <- as.numeric(readline(prompt = "Which statum year do you want to use (Enter: 2010, 2019, or 2022): "))
-2022
-## 2010: for testing to match Stan's code
-## 2019: recent update of strata- used for 2021 assessment
-## 2022: DEFAULT: latest update and strata to use for current assessments
+# Save a copy of the raw data? (y for YES, n for NO)
+stable_data_save <- y
 
-
-# you should always use the most current data.
-# if you wish to save a stable copy of your current data, use the following function:
-
-stable_data_save <- readline(prompt = "Do you want to save a copy of your raw data (Enter: y for YES or n for NO): ")
-y
-# this is the default option, to skip data save, enter "n"
-
-# folders -----------------------------------------------------------------
+# Set up folder 
 dir_thisyr <- paste0(current_year,"_", data_type, "_data_", strat_meta_year, "_strata")
-
-#Only run when starting from scratch
 dir.create(here("output",dir_thisyr))
 
-# * pollock data ----------------------------------------------------------
-# * don't include slope survey for VAST -------------------------------------
-
+# data --------------------------------------------------------------------
+# Don't include slope survey for VAST 
 slope_survey <- slope_survey_d()
 
-# * * haul data -----------------------------------------------------------
-
-## Once per year, when the new survey data is in, you need to update the "valid hauls"
-## Jason Conner put code in the Oracle safe folder to do this.
-## If you do not run this, you will not get the most current year of survey data, 
-##   but you only have to run it once after the survey data are finalized (but it doesn't hurt anything if you run it again)
-## you can run that code by un-commenting and running the following line:
+#' Once per year, when the new survey data is in, you need to update the "valid 
+#' hauls". Jason Conner put code in the Oracle safe folder to do this. If you 
+#' do not run this, you will not get the most current year of survey data, but 
+#' you only have to run it once after the survey data are finalized (but it 
+#' doesn't hurt anything if you run it again). You can run that code by un-
+#' commenting and running the following line:
 
 # RODBC::sqlQuery(channel, "BEGIN safe.UPDATE_SURVEY; END;")
 
-## now you can get the haul data:
-## you pull different hauls depending on whether you are running for model-based or design-based indices/comps
-## design-based indices do not include the NBS prior to 2010, and do not include the non-standard 2018 NBS survey
-## model-based indices include all valid NBS stations throughout the time series, including 2018 NBS survey
+## haul data -----------------------------------------------------------
+
+#' Now you can get the haul data. You pull different hauls depending on whether 
+#' you are running for model-based or design-based indices/comps. Design-based 
+#' indices do not include the NBS prior to 2010, and do not include the non-
+#' standard 2018 NBS survey; model-based indices include all valid NBS stations 
+#' throughout the time series, including 2018 NBS survey.
 
 get_hauls <- haul_data_d(data_selection = data_type, nbs_subarea = NBS_subarea, slope_info = slope_survey)
 

--- a/code/Density_Dep_estimates_MAIN.R
+++ b/code/Density_Dep_estimates_MAIN.R
@@ -67,11 +67,11 @@ library(here)
 library(tidyverse)
 library(RODBC)
 library(janitor)
+library(mgcv)
 
 # library(magrittr)
 # library(lubridate)
 # library(modelr)
-# library(mgcv)
 # library(googledrive)
 
 functions <- list.files(here("functions"))
@@ -146,14 +146,14 @@ NBS_subarea <- c(81, 70, 71, 99) # NBS stratum numbers; added 99 to indicate 201
 strat_meta_year <- 2022
 
 # Set output - model- or design-based
-data_type <- "mb"
+data_type <- "db"
 
 # Set up folder 
 dir_thisyr <- paste0(current_year,"_", data_type, "_data_", strat_meta_year, "_strata")
 dir.create(here("output",dir_thisyr))
 
 # data --------------------------------------------------------------------
-process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = FALSE) {
+process_data <- function(first_run = TRUE, estimate_ages = FALSE, save_data = TRUE) {
   # Don't include slope survey for VAST
   slope_survey <- slope_survey_d()
   
@@ -409,7 +409,7 @@ bootstrapping <- function() {
   }
   
   if(data_type == "db") {
-    bootstrap_stan()
+    bootstrap_stan(cpue_length_table = tables$cpue_length_table, cpue_info = tables$cpue_info)
   }
 }
 

--- a/functions/bootstrap.R
+++ b/functions/bootstrap.R
@@ -180,7 +180,7 @@ bootstrap_stan <- function() {
       ncpue.y.s <- ncpue.y[ncpue.y$SUBSTRATA == jj, ]  # select specific year and strata
       nn <- length(ncpue.y.s[, 1])  # number samples wanted
       samp <- sample.int(nn, size = nn, replace = T)  # randomly pick order, possibly with duplicates
-      ncpue.y.s.n=ncpue.y.s[samp,]  # arrange in random order
+      ncpue.y.s.n <- ncpue.y.s[samp,]  # arrange in random order
       for(jj in subs[-1]) {
         ncpue.y.s <- ncpue.y[ncpue.y$SUBSTRATA == jj, ] 
         nn <- length(ncpue.y.s[, 1])

--- a/functions/bootstrap.R
+++ b/functions/bootstrap.R
@@ -1,0 +1,296 @@
+#' This function is an updated (mostly snytax) version of the boostrapping 
+#' methods for creating the variance-covariance matrix for the design-based
+#' application of the density-dependent correction. Also included is the code
+#' that Caitlin Allen-Akselrud commented out, which includes her attempt at 
+#' creating the var-covar matrix. 
+#' 
+#' The function returns two dataframes that are saved in the design-based data
+#' produced in the main code.
+#' 
+# Author: Caitlin I. Allen Akselrud
+# Updated by: Sophia N. Wassermann
+# Contact: sophia.wassermann@noaa.gov
+# Date created: 2024.12.06
+
+# convert new 4 -----------------------------------------------------------
+# this is the conversion of stan's 'new4.R' which sets up the bootstrapping procedure to generate a v-cov matrix later
+# CORRECTION: Caitlin's method did not produce the same amount of variance in the v-cov matrix, 
+#   so that code is commented out and stan's code is implemented directly
+
+##### caitlin's section ####
+
+# # resample the data for each year and strata
+# resample <- resamp_data(corr_cpue = ddc_table)
+# 
+# # check:
+# # mean(resample$ddc_cpue_kg_ha)
+# # mean(ddc_table$ddc_cpue_kg_ha)
+# # mean(resample$ddc_cpue_num_ha, na.rm = T)
+# # mean(ddc_table$ddc_cpue_num_ha, na.rm = T)
+# 
+# # cpue per station for one resample
+# resample_pop <- resamp_pop(resamp = resample, strata = strata_metadata) %>% 
+#   dplyr::filter(!is.na(year))
+# 
+# # CIA: YOU ARE HERE (last part of new4.R)
+# param_sample <- sample(1000,1000,replace=T)
+# 
+# biomass <- matrix(nrow = length(param_sample), ncol = dim(resample_pop)[1])
+# population <- matrix(nrow = length(param_sample), ncol = dim(resample_pop)[1])
+# 
+# 
+# v_cov_units <- readline(prompt = "Which units do you want to use in the v-cov matrix (Enter: k for kg or t for th t): ")
+# 
+# k 
+# 
+# if(v_cov_units == 'k') 
+# {
+#   biomass <- foreach(i = 1:1000, .combine=rbind) %dopar% {
+#     library(magrittr)
+#     library(tidyverse)
+#     
+#     param_sample <- sample(1000,1,replace=T)
+#     
+#     # estimate ddc with random sample from parameter posterior distribution
+#     backscatter_cpue_corr <- ddc_cpue_bs(equiv_bs_length, param_ests[param_sample,])
+#     
+#     # turn backscatter into cpue
+#     ddc_table_vc <- ddc_fxn(backscatter_cpue_corr, cpue_info$p_cpue) #backscatter corr from EACH SAMPLE
+#     
+#     # randomly resample data from all years and all stations
+#     resample <- resamp_data(ddc_table_vc) #FOR EACH SAMPLE
+#     
+#     # get total population est from each resample for each year (cpue*area)
+#     resample_pop <- resamp_pop(resample, strata_metadata) %>%  #FOR EACH SAMPLE
+#       dplyr::filter(!is.na(year))
+#     
+#     # save resampled biomass
+#     resample_pop$total_ddc_kg #EACH ROW IS RESAMPLE, EACH COL IS YEARS
+#   }
+#   
+#   write_csv(as.data.frame(biomass), here("output",dir_thisyr,paste0("bootstrap_biomass_kg_", data_type, ".csv")))
+# } else if(v_cov_units == 't') {
+#   biomass <- foreach(i = 1:1000, .combine=rbind) %dopar% {
+#     library(magrittr)
+#     library(tidyverse)
+#     
+#     param_sample <- sample(1000,1,replace=T)
+#     
+#     # estimate ddc with random sample from parameter posterior distribution
+#     backscatter_cpue_corr <- ddc_cpue_bs(equiv_bs_length, param_ests[param_sample,])
+#     
+#     # turn backscatter into cpue
+#     ddc_table_vc <- ddc_fxn(backscatter_cpue_corr, cpue_info$p_cpue) #backscatter corr from EACH SAMPLE
+#     
+#     # randomly resample data from all years and all stations
+#     resample <- resamp_data(ddc_table_vc) #FOR EACH SAMPLE
+#     
+#     # get total population est from each resample for each year (cpue*area)
+#     resample_pop <- resamp_pop(resample, strata_metadata) %>%  #FOR EACH SAMPLE
+#       dplyr::filter(!is.na(year))
+#     
+#     # save resampled biomass
+#     resample_pop$total_ddc_th_t #EACH ROW IS RESAMPLE, EACH COL IS YEARS
+#   }
+#   
+#   write_csv(as.data.frame(biomass), here("output",dir_thisyr,paste0("bootstrap_biomass_th_t_", data_type, ".csv")))
+# } else(print("Invalid selection: please select k for kg or t for th t"))
+
+# v-cov check
+# sqrt(diag(biomass))/mean(diag(biomass))
+
+#### stan's bootstrapping method: ####
+bootstrap_stan <- function() {
+  if(data_type == "db") {
+    corr_sa <-  function(aa,ab){
+      # calculates corrected sa by tow (corrected backscatter by tow)
+      by1 <- list(haul = aa$HAUL, subst = aa$SUBSTRATA, vessel = aa$VESSEL, year = aa$YEAR)
+      sa_station <- aggregate(aa$bt_sa, by1, sum)
+      str(sa_station)
+      # hist(sa_station$x, 2000, xlim=c(0,5000))
+      
+      ii <- 1 
+      sa_corr <- sa_station$x[ii] / (ab$asp + exp(-(ab$int + ab$slope * sa_station$x[ii])))
+      corr_mean <- mean(sa_corr)
+      corr_sd <- sd(sa_corr)
+      
+      for(ii in 2:length(sa_station$x)) {
+        sa_corr <- sa_station$x[ii] / (ab$asp + exp(-(ab$int + ab$slope * sa_station$x[ii])))
+        corr_mean[ii]=mean(sa_corr)
+        corr_sd[ii] = sd(sa_corr) #might need na.rm = T
+      }
+      
+      # this data contains old and new estimates of sa (uncorrected and corrected backscatter estimates returned)
+      sa_sum <- cbind(sa_station,corr_mean,corr_sd)
+      return(sa_sum)
+    }
+    
+    corr_cpue <- function(sa,bb) {
+      # calculates new cpue per tow (applies bs correction; eff = efficency; eff = ratio uncorr to corr, less than 1)
+      eff <- sa$x / sa$corr_mean
+      sa <- cbind(sa,eff)
+      # str(sa)
+      
+      cc <- merge(bb,sa,all=T)
+      
+      new_kgha <- cc$CPUE_KGHA/cc$eff
+      new_noha <- cc$CPUE_NOHA/cc$eff
+      
+      pollock_cpue_new <- cbind(cc[, c(1:11, 16)], new_kgha, new_noha)
+      # str(pollock_cpue_new)
+      pollock_cpue_new$new_kgha[pollock_cpue_new$CPUE_KGHA == 0] <- 0
+      pollock_cpue_new$new_noha[pollock_cpue_new$CPUE_NOHA == 0] <- 0
+      pollock_cpue_new$eff[pollock_cpue_new$CPUE_KGHA == 0] <- 1
+      # write.csv(pollock_cpue_new, "pollock_cpue_new.csv")
+      
+      na.eff.cpue <- data.frame(xx = pollock_cpue_new[which(is.na(pollock_cpue_new$eff)), ]$CPUE_KGHA)
+      na.eff.cpue.idx <- which(is.na(pollock_cpue_new$eff))
+      
+      xx <- pollock_cpue_new$CPUE_KGHA
+      yy <- pollock_cpue_new$eff
+      # plot(yy~xx)
+      gam1 <- gam(yy ~ s(xx))
+      # summary(gam1)
+      # plot(gam1)
+      
+      na.eff <- predict(gam1, na.eff.cpue)
+      pollock_cpue_new$eff[na.eff.cpue.idx] <- na.eff
+      pollock_cpue_new$new_kgha[na.eff.cpue.idx] <- pollock_cpue_new$CPUE_KGHA[na.eff.cpue.idx] / na.eff
+      pollock_cpue_new$new_noha[na.eff.cpue.idx] <- pollock_cpue_new$CPUE_NOHA[na.eff.cpue.idx] / na.eff
+      # write.csv(pollock_cpue_new, "pollock_cpue_new.csv")
+      # str(pollock_cpue_new)
+      
+      pollock_cpue_new2 <- pollock_cpue_new[, c(1:8, 13:14, 11)]
+      # str(pollock_cpue_new2)
+      colnames(pollock_cpue_new2)[c(1:3, 9, 10)] <- c("VESSEL", "YEAR", "HAUL", 
+                                                      "CPUE_KGHA","CPUE_NOHA")
+      # str(pollock_cpue_new2)
+      
+      return(pollock_cpue_new2) #returns the DDC cpue
+    }
+    
+    ncpue_sample <- function(ncpue) {
+      first.y <- min(ncpue$YEAR) #for each year
+      last.y <- max(ncpue$YEAR)
+      
+      ii <- first.y
+      ncpue.y <- ncpue[ncpue$YEAR == ii, ]  # select a specific year
+      subs <- unique(ncpue.y$SUBSTRATA)  # for each strata; get strata from that year
+      jj <- subs[1]
+      ncpue.y.s <- ncpue.y[ncpue.y$SUBSTRATA == jj, ]  # select specific year and strata
+      nn <- length(ncpue.y.s[, 1])  # number samples wanted
+      samp <- sample.int(nn, size = nn, replace = T)  # randomly pick order, possibly with duplicates
+      ncpue.y.s.n=ncpue.y.s[samp,]  # arrange in random order
+      for(jj in subs[-1]) {
+        ncpue.y.s <- ncpue.y[ncpue.y$SUBSTRATA == jj, ] 
+        nn <- length(ncpue.y.s[, 1])
+        samp <- sample.int(nn, size = nn, replace = T)
+        ncpue.y.s.n <- rbind(ncpue.y.s.n,ncpue.y.s[samp, ])
+        # estimate of one realization of estimating cpue; with all substrata, 1st year
+      }
+      ncpue.y.n <- ncpue.y.s.n
+      
+      for(ii in (first.y + 1):last.y) {  # this is for all remaining years (with all substrata)
+        ncpue.y <- ncpue[ncpue$YEAR == ii, ]
+        subs <- unique(ncpue.y$SUBSTRATA)
+        jj <- subs[1]
+        ncpue.y.s <- ncpue.y[ncpue.y$SUBSTRATA == jj, ]
+        nn <- length(ncpue.y.s[, 1])
+        samp <- sample.int(nn, size = nn, replace = T)
+        ncpue.y.s.n <- ncpue.y.s[samp, ]
+        for(jj in subs[-1]){
+          ncpue.y.s <- ncpue.y[ncpue.y$SUBSTRATA == jj, ]
+          nn <- length(ncpue.y.s[, 1])
+          samp <- sample.int(nn, size = nn, replace = T)
+          ncpue.y.s.n <- rbind(ncpue.y.s.n, ncpue.y.s[samp, ])
+        }
+        ncpue.y.n <- rbind(ncpue.y.n,ncpue.y.s.n)
+        
+      }
+      return(ncpue.y.n) #one realization of cpue est for all years and all substrata
+    }
+    
+    corr_population <- function(aa,bb) {
+      by1 <- list(aa$YEAR, aa$SUBSTRATA)
+      cc <- aggregate(cbind(aa$CPUE_KGHA, aa$CPUE_NOHA), by1, mean, na.rm = T)  # get mean by year and strata
+      colnames(cc) <- c("year", "substrata", "m_kgha", "m_noha")
+      colnames(bb) <- c("substrata", "area")
+      cc1 <- merge(cc, bb, all = T)  # add area back
+      # cc1=cc1[cc1$substrata!=70,]  # filter out NBS
+      # cc1=cc1[cc1$substrata!=81,]
+      pop_by_strata <- cc1[, 3:4] * cc1[, 5]  # get number by multiplying cpue by area fished (cpue = num/ha; area = km^2; need to *100 to get km^2 -> ha-- done 3 lines below)
+      by2 <- list(cc1$year)
+      total_pop <- aggregate(pop_by_strata, by2, sum)  # sum by year
+      total_pop1 <- cbind(year = total_pop[, 1], tons = total_pop[, 2] / 10, mlns = total_pop[, 3] / 10000) # years, convert to kg to tons, convernt num to millions
+      return(total_pop1)
+    }
+    
+    ab <- param_ests
+    
+    bb <- cpue_info$p_cpue %>%  #cpue
+      rename(CRUISE = cruise, SUBSTRATA = stratum, 
+             LATITUDE = start_latitude, LONGITUDE = start_longitude,
+             CPUE_KGHA = cpue_kg_ha, CPUE_NOHA = cpue_num_ha, AREA_FISHED = area_fished_ha) %>% 
+      mutate(SPECIES_CODE = 21740) %>% 
+      select("vessel", "CRUISE", "year", "haul", "SUBSTRATA", "LATITUDE", "LONGITUDE", 
+             "SPECIES_CODE", "CPUE_KGHA", "CPUE_NOHA", "AREA_FISHED") #%>% 
+    # dplyr::filter(!SUBSTRATA %in% NBS_subarea)
+    
+    # bb_sub <- bb %>% dplyr::select("vessel", "CRUISE", "year", "haul", "SUBSTRATA", "LATITUDE", "LONGITUDE") %>% 
+    #   clean_names(case = 'all_caps')
+    
+    aa <- equiv_bs_length %>%  #cpue length
+      clean_names(case = 'all_caps') %>% 
+      rename(cpue_mile = CPUE_MILE_SQ, ts = TARGET_STRENGTH, bt_sa = BACKSCATTER, 
+             CRUISE = CRUISEJOIN, SUBSTRATA = STRATUM, CPUE_LENGTH = CPUE_LENGTH_NUM_HA) %>%
+      # left_join(bb_sub) %>% 
+      mutate(LATITUDE = NA, LONGITUDE = NA, 
+             SPECIES_CODE = 21740) %>% 
+      select("VESSEL", "YEAR", "CRUISE", "HAUL", "LATITUDE", "LONGITUDE", "SUBSTRATA", 
+             "STATIONID", "SPECIES_CODE", "SEX", "LENGTH", "CPUE_LENGTH", 
+             "cpue_mile",  "ts", "bt_sa") #%>% 
+    # dplyr::filter(!SUBSTRATA %in% NBS_subarea)
+    
+    gg <- strata_metadata %>%  #strata
+      rename(area_ha = area) %>% 
+      select( "stratum", "area_ha") #%>% 
+    # dplyr::filter(!stratum %in% NBS_subarea)
+    
+    ii <- sample(1000, 1)  # random number btw 1 and 1000
+    sa_sum <- corr_sa(aa, ab[ii, ])  # estimates corr sa based on params from abc_exp
+    ncpue <- corr_cpue(sa_sum, bb)  # estimates cpue based on param
+    ncpue.s <- ncpue_sample(ncpue)  # gets ncpue sample
+    estim <- corr_population(ncpue.s, gg)  # get corr pop based on random param selected
+    pops <- estim[, 3]  # pop vector
+    bioms <- estim[, 2]  # biomass vector
+    
+    for(ii in sample(1000, 999, replace = T)) {  # run 1000 times (999 more times), randomly sampling
+      sa_sum <- corr_sa(aa, ab[ii, ])
+      ncpue <- corr_cpue(sa_sum, bb)
+      ncpue.s <- ncpue_sample(ncpue)
+      estim <- corr_population(ncpue.s, gg)
+      popsii <- estim[, 3]
+      biomsii <- estim[, 2]
+      pops <- rbind(pops, popsii)  # rows = resamples, cols = yrs
+      bioms <- rbind(bioms, biomsii)
+      print(length(pops[, 1]))
+    }
+    
+    colnames(bioms) <- unique(aa$YEAR)
+    bioms
+    var_covar_stan <- cov(bioms)
+    colnames(var_covar_stan) <- unique(aa$YEAR)
+    rownames(var_covar_stan) <- unique(aa$YEAR)
+    
+    # check:
+    biomass_mean <- bioms %>% 
+      as_tibble() %>% 
+      summarise_if(is.numeric, mean) 
+    colnames(biomass_mean) <- unique(ddc_table$year)
+    cv <- sqrt(diag(var_covar_stan)) / biomass_mean
+    range(cv)  # range should be 5-20%
+    if(max(range(cv)) > 0.2) {print("YOUR CV IS > 20% PLEASE CHECK")}
+  }
+  
+  return(list(bioms = bioms, var_covar_stan = var_covar_stan))
+}

--- a/functions/bootstrap.R
+++ b/functions/bootstrap.R
@@ -100,7 +100,7 @@
 # sqrt(diag(biomass))/mean(diag(biomass))
 
 #### stan's bootstrapping method: ####
-bootstrap_stan <- function() {
+bootstrap_stan <- function(cpue_length_table, cpue_info) {
   if(data_type == "db") {
     corr_sa <-  function(aa,ab){
       # calculates corrected sa by tow (corrected backscatter by tow)
@@ -225,6 +225,7 @@ bootstrap_stan <- function() {
       return(total_pop1)
     }
     
+    param_ests <-  read_csv(here("from_stan", "abc_exp.csv"))
     ab <- param_ests
     
     bb <- cpue_info$p_cpue %>%  #cpue
@@ -239,6 +240,7 @@ bootstrap_stan <- function() {
     # bb_sub <- bb %>% dplyr::select("vessel", "CRUISE", "year", "haul", "SUBSTRATA", "LATITUDE", "LONGITUDE") %>% 
     #   clean_names(case = 'all_caps')
     
+    equiv_bs_length <- backscatter_est(cpue_length_table)
     aa <- equiv_bs_length %>%  #cpue length
       clean_names(case = 'all_caps') %>% 
       rename(cpue_mile = CPUE_MILE_SQ, ts = TARGET_STRENGTH, bt_sa = BACKSCATTER, 

--- a/functions/get_data.R
+++ b/functions/get_data.R
@@ -4,8 +4,7 @@
 # Date created: 2022.06.02
 # Date updated: 2022.06.02
 
-slope_survey_d <- function()
-{
+slope_survey_d <- function() {
   query_command <- paste0(" select * from SAFE.survey;")
   all_survey_info <- sqlQuery(channel, query_command) %>% 
     as_tibble() %>% 
@@ -17,8 +16,7 @@ slope_survey_d <- function()
   return(slope_survey)
 }
 
-haul_data_d <- function(data_selection = "db", nbs_subarea = c(81, 70, 71), slope_info)
-{
+haul_data_d <- function(data_selection = "db", nbs_subarea = c(81, 70, 71), slope_info) {
   # DB: design-based: ebs and nbs separate; nbs = 2010+; no 2018 nbs
   # through 2021
   query_command <- paste0("select * from SAFE.pollock_historical_design_hauls")
@@ -165,9 +163,7 @@ haul_data_d <- function(data_selection = "db", nbs_subarea = c(81, 70, 71), slop
   
 }
 
-specimen_data_d <- function(hauls_survey_dat)
-{
-  hauls_survey_dat <- hauls_survey
+specimen_data_d <- function(hauls_survey_dat) {
   hauljoins <- hauls_survey_dat$hauljoin
   # SNW: remove "and a.age is not null" to create estimated ALK for current year
   query_command <- paste0("select a.CRUISEJOIN, a.HAULJOIN, a.REGION, a.VESSEL, a.CRUISE, a.HAUL,
@@ -189,8 +185,7 @@ specimen_data_d <- function(hauls_survey_dat)
   return(pollock_spec)
 }
 
-catch_data_d <- function(hauljoins)
-{
+catch_data_d <- function(hauljoins) {
   query_command <- paste0(" SELECT * FROM racebase.catch
                            WHERE region='BS' and species_code = 21740")
   pollock_catch <- sqlQuery(channel, query_command) %>% 
@@ -200,8 +195,7 @@ catch_data_d <- function(hauljoins)
   return(pollock_catch)
 }
 
-length_data_d <- function(hauljoins)
-{
+length_data_d <- function(hauljoins) {
   query_command <- paste0(" SELECT * FROM racebase.length
                            WHERE region='BS' and species_code = 21740")
   pollock_length <- sqlQuery(channel, query_command) %>% 
@@ -231,8 +225,7 @@ length_data_d <- function(hauljoins)
               pollock_raw_length = pollock_raw_length))
 }
 
-metadata_d <- function(cruise_id = cruise, vessel_code_id = vessel_code, pollock_specimen_data = pollock_specimen, meta_select = strat_meta_year)
-{
+metadata_d <- function(cruise_id = cruise, vessel_code_id = vessel_code, pollock_specimen_data = pollock_specimen, meta_select = strat_meta_year) {
   # get most recent year of metadata (most recent cruise and vessel)
   query_command <- paste0(" SELECT * FROM racebase.cruise WHERE cruise in (",
                           cruise_id, ") and region='BS' and vessel in(", vessel_code_id, "); ")

--- a/functions/get_data.R
+++ b/functions/get_data.R
@@ -170,8 +170,8 @@ specimen_data_d <- function(hauls_survey_dat) {
                               a.SPECIMENID, a.BIOSTRATUM, a.SPECIES_CODE, round(a.LENGTH/10)*10 length, a.SEX, a.WEIGHT,
                               a.AGE, a.MATURITY, a.MATURITY_TABLE, a.GONAD_WT, a.AUDITJOIN
                             from racebase.specimen a
-                            where species_code = 21740 and a.age is not null
-                            order by cruise, vessel, haul;")
+                            where species_code = 21740", if(estimate_ages == TRUE) {" and a.age is not null"},
+                            " order by cruise, vessel, haul;")
   
   pollock_specimen_orig <- sqlQuery(channel, query_command) %>% 
     as_tibble() %>% 

--- a/functions/make_VAST_input.R
+++ b/functions/make_VAST_input.R
@@ -8,7 +8,8 @@
 make_VAST_input <- function(hauls = hauls_survey,
                             spec = pollock_specimen,
                             ddc_index = ddc_table,
-                            ddc_age = ddc_alk)
+                            ddc_age = ddc_alk,
+                            slope_survey = slope_survey)
 {
   # add in 2018 NBS emergency survey (read_csv)
   # ddc_table_2018 <- read_csv(here("output", "VAST_ddc_2018_NBS_addon.csv")) %>% 


### PR DESCRIPTION
In an effort to make this script easier (for me) to debug and run, I have reformatted this script into a series of functions with inputs that are either defined at the top of the script or set as default input to the functions. None of the outputs have changed. My goal was to avoid saving every step as an environment variable, to group together related steps (data processing, density-dependent correction, bootstrapping, and data export), and to remove legacy code.

To this last point, I moved the bootstrapping, based on a method by Stan Kotwicki, to a function in its own script and removed commented-out lines that I have never used. 

Lastly, I added in a switch for whether to estimate missing ages using the age-length key. This is necessary when ages (in the specimen data) are not available for the current year. While this should not be an issue regularly, this switch allows the code to be run before ages are available and is a failsafe for producing the density corrected data if there is an issue with aging.

I have tagged [the last commit](https://github.com/afsc-gap-products/pollock-ddc/commit/3d3be52a8dfb066849d8c60d956c38d986d837d4) before these updates for future reference.
